### PR TITLE
A few scripts for container startup

### DIFF
--- a/scripts/entryPoint.sh
+++ b/scripts/entryPoint.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+source /etc/profile
+echo SYSID_THISMAV=$1 >> /ardupilot/Tools/autotest/default_params/plane.parm
+grep SYSID_THISMAV /ardupilot/Tools/autotest/default_params/plane.parm
+echo $SIM_OPTIONS
+sim_vehicle.py --speedup=$SPEEDUP $SIM_OPTIONS

--- a/scripts/entryPoint.sh
+++ b/scripts/entryPoint.sh
@@ -1,6 +1,4 @@
 #! /bin/bash
 source /etc/profile
-echo SYSID_THISMAV=$1 >> /ardupilot/Tools/autotest/default_params/plane.parm
-grep SYSID_THISMAV /ardupilot/Tools/autotest/default_params/plane.parm
-echo $SIM_OPTIONS
+echo SYSID_THISMAV=$1 | tee -a /ardupilot/Tools/autotest/default_params/plane.parm
 sim_vehicle.py --speedup=$SPEEDUP $SIM_OPTIONS

--- a/scripts/runMAV-macos.sh
+++ b/scripts/runMAV-macos.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+$(dirname $0)/runMAV.sh $1 docker.for.mac.localhost $2
+exit $?

--- a/scripts/runMAV.sh
+++ b/scripts/runMAV.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+if [ $# -ne 2 ] 
+then
+  echo "Usage: runMAV.sh <system_id> <gcs_port>"
+  exit 1
+fi
+
+SCRIPTS_DIR=$(cd $(dirname $(which $0)); pwd)
+docker run --rm -it -v $SCRIPTS_DIR:/external -e "SIM_OPTIONS=--out=udpout:docker.for.mac.localhost:$2 -m --target-system=$1" --entrypoint "/external/entryPoint.sh" gmyoungbloodparc/ardupilot-sitl $1
+exit $?

--- a/scripts/runMAV.sh
+++ b/scripts/runMAV.sh
@@ -1,11 +1,18 @@
 #! /bin/bash
 
-if [ $# -ne 2 ] 
+if [ $# -ne 3 ] 
 then
-  echo "Usage: runMAV.sh <system_id> <gcs_port>"
+  echo "Usage: runMAV.sh <system_id> <gcs_host> <gcs_port>"
   exit 1
 fi
 
+SYS_ID=$1
+GCS_HOST=$2
+GCS_PORT=$3
 SCRIPTS_DIR=$(cd $(dirname $(which $0)); pwd)
-docker run --rm -it -v $SCRIPTS_DIR:/external -e "SIM_OPTIONS=--out=udpout:docker.for.mac.localhost:$2 -m --target-system=$1" --entrypoint "/external/entryPoint.sh" gmyoungbloodparc/ardupilot-sitl $1
+
+echo "Running SITL simulation ..."
+echo SYS_ID=$SYS_ID GCS_HOST=$2 GCS_PORT=$3
+
+docker run --rm -it -v $SCRIPTS_DIR:/external -e "SIM_OPTIONS=--out=udpout:$GCS_HOST:$GCS_PORT -m --target-system=$SYS_ID" --entrypoint "/external/entryPoint.sh" gmyoungbloodparc/ardupilot-sitl $SYS_ID
 exit $?


### PR DESCRIPTION
Here are a few simple scripts facilitate setting the system id, GCS host and port on startup, in relation to issue #1. They can be found in the `scripts` directory.

The system id setting in particular is necessary to run several containers, i.e. simulate several MAVs properly.  The same GCS host/port pair may be used for all containers in principle if you wish (e.g., it works well with QGroundControl).

Let me know if there are any issues / feel free to adapt.

Best,
Eduardo